### PR TITLE
Changed deploy trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,9 +5,8 @@
 name: Release (Deploy to S3)
 
 on:
-  push:
-    tags:
-      - 'v*' # Push events to matching v*, i.e. v1.0
+  release:
+    types: [released]
 
 env:
   AWS_SECRET_ACCESS_KEY : ${{secrets.AWS_SECRET_ACCESS_KEY}}


### PR DESCRIPTION
The trigger for deploy to s3 was changed from push tags, to on a new release.